### PR TITLE
Add product route for detail pages

### DIFF
--- a/src/app/app-routing-module.ts
+++ b/src/app/app-routing-module.ts
@@ -10,6 +10,7 @@ const routes: Routes = [
   {path: 'products', component: Products},
   {path: 'cart', component: Cart},
   {path: 'login', component: Login},
+  {path: 'product/:id', component: ProductDetail},
   {path: 'product-detail', component: ProductDetail},
   {path: '', redirectTo: '/home', pathMatch: 'full'},
   {path: '**', redirectTo: '/home'}

--- a/src/app/components/product-card/product-card.ts
+++ b/src/app/components/product-card/product-card.ts
@@ -19,16 +19,7 @@ export class ProductCard  {
   @Input() products: Product[] = [];
 
   navigateToProduct(product: Product) {
-    this.router.navigate(['/product-detail'], {
-      queryParams: {
-        id: product.id,
-        name: product.name,
-        description: product.description,
-        price: product.price,
-        image: product.image,
-        category: product.category
-      }
-    });
+    this.router.navigate(['/product', product.id]);
   }
 
   addToCard(productId : number){

--- a/src/app/pages/product-detail/product-detail.ts
+++ b/src/app/pages/product-detail/product-detail.ts
@@ -1,7 +1,8 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { Product } from '../../models/product.model';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { CartService } from '../../services/cart.service';
+import { ProductService } from '../../services/product.service';
 
 @Component({
   selector: 'app-product-detail',
@@ -22,20 +23,19 @@ export class ProductDetail implements OnInit {
     image: '',
     category:''
   }
-  constructor(private route: ActivatedRoute){}
+  constructor(
+    private route: ActivatedRoute,
+    private productService: ProductService,
+  ){}
 
 
   ngOnInit() {
-    this.route.queryParams.subscribe(params => {
-      if (params['id']) {
-        this.product = {
-          id: +params['id'], // Convert string to number
-          name: params['name'] || '',
-          description: params['description'] || '',
-          price: +params['price'] || 0, // Convert string to number
-          image: params['image'] || '',
-          category: params['category'] || ''
-        };
+    this.route.params.subscribe(params => {
+      const id = +params['id'];
+      if (id) {
+        this.productService.getProductById(id).subscribe(product => {
+          this.product = product;
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- add dynamic product detail route
- update ProductCard to navigate using route params
- load product details via ProductService

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688d63ea560c832ba1a956ef2a04c484